### PR TITLE
Added support for EAN_128 (found in extended property).

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Android: https://github.com/dm77/barcodescanner
 - [x] Scan QR codes
 - [x] Control the flash while scanning
 - [x] Permission handling
+- [x] Added extended property to tell if this is a EAN128 vs CODE128
 
 ## Getting Started
 

--- a/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScanPlugin.kt
+++ b/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScanPlugin.kt
@@ -47,7 +47,7 @@ class BarcodeScanPlugin(private val registrar: Registrar) : MethodCallHandler, P
                 val barcode = data?.getStringExtra("SCAN_RESULT")
                 val barcodeFormat = data?.getStringExtra("BARCODE_FORMAT")
                 barcode?.let { this.result?.success(mapOf("barcode" to barcode,
-                        "barcodeFormat" to barcodeFormat)) }
+                        "barcodeFormat" to barcodeFormat, "extended" to data?.getStringExtra("EXTENDED") ) ) }
             } else {
                 val errorCode = data?.getStringExtra("ERROR_CODE")
                 this.result?.error(errorCode, null, null)

--- a/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScannerActivity.kt
+++ b/android/src/main/kotlin/de/mintware/barcode_scan/BarcodeScannerActivity.kt
@@ -102,7 +102,8 @@ class BarcodeScannerActivity : Activity(), ZXingScannerView.ResultHandler {
     override fun handleResult(result: Result?) {
         val intent = Intent()
         intent.putExtra("SCAN_RESULT", result.toString())
-        intent.putExtra("BARCODE_FORMAT", result?.barcodeFormat.toString())
+        intent.putExtra("EXTENDED", if((result?.rawBytes?.size ?: 0)>1 && result!!.rawBytes[0].toInt()==105){ if(result!!.rawBytes[1].toInt()==102) "EAN_128" else "CODE_128"} else "")
+				intent.putExtra("BARCODE_FORMAT", result?.barcodeFormat.toString())
         setResult(RESULT_OK, intent)
         finish()
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,8 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   String barcode = "";
+  String barcodeFormat = "";
+  String barcodeExtended = "";
 
   @override
   initState() {
@@ -32,11 +34,12 @@ class _MyAppState extends State<MyApp> {
             child: new Column(
               children: <Widget>[
                 new Container(
-                  child: new MaterialButton(
-                      onPressed: scan, child: new Text("Scan")),
+                  child: new MaterialButton(onPressed: scan, child: new Text("Scan")),
                   padding: const EdgeInsets.all(8.0),
                 ),
-                new Text(barcode),
+                Text(barcode),
+                Text(barcodeFormat),
+                Text(barcodeExtended),
               ],
             ),
           )),
@@ -46,7 +49,12 @@ class _MyAppState extends State<MyApp> {
   Future scan() async {
     try {
       Map barcode = await BarcodeScanner.scan();
-      setState(() => this.barcode = barcode['barcode']);
+      setState(() {
+        print('Keys: ${barcode.keys}');
+        this.barcodeFormat = barcode['barcodeFormat'];
+        this.barcodeExtended = barcode['extended'];
+        this.barcode = barcode['barcode'];
+      });
     } on PlatformException catch (e) {
       if (e.code == BarcodeScanner.CameraAccessDenied) {
         setState(() {
@@ -55,7 +63,7 @@ class _MyAppState extends State<MyApp> {
       } else {
         setState(() => this.barcode = 'Unknown error: $e');
       }
-    } on FormatException{
+    } on FormatException {
       setState(() => this.barcode = 'null (User returned using the "back"-button before scanning anything. Result)');
     } catch (e) {
       setState(() => this.barcode = 'Unknown error: $e');


### PR DESCRIPTION
Updated example to show the updated values (barcodetype and extended property)
The updated value can be found in barcode['extended'] this will have "EAN_128" or "CODE_128" if it has the FNC1 set. Other codes will have this extended value empty.
Only fixed for Android since I don't have the needed IOS knowledge